### PR TITLE
give up own install export file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,11 +26,6 @@ target_link_libraries(async_json INTERFACE hsm)
 target_include_directories(async_json INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
     $<INSTALL_INTERFACE:include>
     )
-install(TARGETS async_json EXPORT async_json-Targets DESTINATION include)
-install(EXPORT async_json-Targets
-    NAMESPACE async_json::
-    DESTINATION lib/cmake/async_json
-    )
 
 if(async_json_BUILD_TESTS)
     add_subdirectory(test)


### PR DESCRIPTION
async_json has direct dependency to hsm and indirect dependencies to the hsm subdependencies which are known known at this point.
The problem is that all dependencies needs to be listed in the install exports.